### PR TITLE
Fix hide code

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -103,17 +103,23 @@ ${files.map((_, index) => `    whenReady${index}()`).join(',\n')}
           breakpoints,
           taskDefinitions,
           viewsWelcome,
+          terminal,
+          viewsContainers,
           ...remainingContribute
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } = manifest.contributes as any
+        } = manifest.contributes ?? {}
 
         const {
+          activationEvents,
+          devDependencies,
+          dependencies,
+          scripts,
           browser,
           main,
           l10n,
           extensionDependencies, // for pure-d that requires hbenl.vscode-test-explorer
           ...remainingManifest
-        } = manifest
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } = manifest as any
 
         return {
           ...remainingManifest,

--- a/src/types/monaco.d.ts
+++ b/src/types/monaco.d.ts
@@ -5,7 +5,7 @@ declare module 'monaco-editor' {
         interface ICodeEditor {
             // This method is internal and is supposed to be used by the folding feature
             // We still use it to hide parts of the code in the `hideCodeWithoutDecoration` function
-            setHiddenAreas(ranges: IRange[]): void
+            setHiddenAreas(ranges: IRange[], source?: unknown): void
 
             _getViewModel(): {
                 getHiddenAreas(): IRange[]


### PR DESCRIPTION
the `setHiddenArea` feature was improved by adding a `source` parameter to prevent conflict in https://github.com/microsoft/vscode/commit/3edcbec59a15e6bec9538d37b9ac47702d90a3a4

It break our implementation of `hideCodeWithoutDecoration` but also allow to make it much more simple and less hacky