### PR TITLE
Improve lock and collapse code features

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ It also includes some tools allowing to add some missing features to monaco-edit
 - `hideCodeWithoutDecoration` allows to hide code parts that have a specific decoration
 - `lockCodeWithoutDecoration` allows to make read-only code parts that have a specific decoration
 - `updateEditorKeybindingsMode` allows to apply vim or emacs keybindings
+- `extractRangesFromTokens` allows to extract a code section between 2 tokens
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ It also includes some tools allowing to add some missing features to monaco-edit
 - `collapseCodeSections` allows to create and collapse a code section between 2 tokens
 - `registerTextDecorationProvider` allows to compute decorations on all existing editors
 - `hideCodeWithoutDecoration` allows to hide code parts that have a specific decoration
-- `lockCodeSectionsFromRanges` allows to make a code section read-only
-- `lockCodeSectionsWithoutRanges` allows to make the code outside of a code section read-only
 - `lockCodeFromDecoration` allows to make read-only code parts within a specific decoration
 - `lockCodeWithoutDecoration` allows to make read-only code parts outside of a specific decoration
 - `updateEditorKeybindingsMode` allows to apply vim or emacs keybindings

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It also includes some tools allowing to add some missing features to monaco-edit
 - `collapseCodeSections` allows to create and collapse a code section between 2 tokens
 - `registerTextDecorationProvider` allows to compute decorations on all existing editors
 - `hideCodeWithoutDecoration` allows to hide code parts that have a specific decoration
-- `lockCodeFromDecoration` allows to make read-only code parts within a specific decoration
+- `lockCodeWithDecoration` allows to make read-only code parts within a specific decoration
 - `lockCodeWithoutDecoration` allows to make read-only code parts outside of a specific decoration
 - `updateEditorKeybindingsMode` allows to apply vim or emacs keybindings
 - `extractRangesFromTokens` allows to extract a code section between 2 tokens

--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ It also includes some tools allowing to add some missing features to monaco-edit
 - `collapseCodeSections` allows to create and collapse a code section between 2 tokens
 - `registerTextDecorationProvider` allows to compute decorations on all existing editors
 - `hideCodeWithoutDecoration` allows to hide code parts that have a specific decoration
-- `lockCodeWithoutDecoration` allows to make read-only code parts that have a specific decoration
+- `lockCodeSectionsFromRanges` allows to make a code section read-only
+- `lockCodeSectionsWithoutRanges` allows to make the code outside of a code section read-only
+- `lockCodeFromDecoration` allows to make read-only code parts within a specific decoration
+- `lockCodeWithoutDecoration` allows to make read-only code parts outside of a specific decoration
 - `updateEditorKeybindingsMode` allows to apply vim or emacs keybindings
 - `extractRangesFromTokens` allows to extract a code section between 2 tokens
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Monaco editor wrapper uses and configures [monaco-vscode-api](https://www.npmjs.
 
 It also includes some tools allowing to add some missing features to monaco-editor:
 - `preventAlwaysConsumeTouchEvent`, mobile feature corresponding to the `alwaysConsumeMouseWheel` monaco-editor option
+- `collapseCodeSectionsFromRanges` allows to create and collapse a code section
 - `collapseCodeSections` allows to create and collapse a code section between 2 tokens
 - `registerTextDecorationProvider` allows to compute decorations on all existing editors
 - `hideCodeWithoutDecoration` allows to hide code parts that have a specific decoration

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ It also includes some tools allowing to add some missing features to monaco-edit
 - `lockCodeWithoutDecoration` allows to make read-only code parts outside of a specific decoration
 - `updateEditorKeybindingsMode` allows to apply vim or emacs keybindings
 - `extractRangesFromTokens` allows to extract a code section between 2 tokens
+- `createDecorationsForRanges` allows to create a decoraton for a code section
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It also includes some tools allowing to add some missing features to monaco-edit
 - `lockCodeWithDecoration` allows to make read-only code parts within a specific decoration
 - `lockCodeWithoutDecoration` allows to make read-only code parts outside of a specific decoration
 - `updateEditorKeybindingsMode` allows to apply vim or emacs keybindings
-- `extractRangesFromTokens` allows to extract a code section between 2 tokens
+- `extractRangesFromTokens` allows to extract the code sections between a start token and an end token
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ It also includes some tools allowing to add some missing features to monaco-edit
 - `lockCodeWithoutDecoration` allows to make read-only code parts outside of a specific decoration
 - `updateEditorKeybindingsMode` allows to apply vim or emacs keybindings
 - `extractRangesFromTokens` allows to extract a code section between 2 tokens
-- `createDecorationsForRanges` allows to create a decoraton for a code section
 
 ### Installation
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -65,15 +65,6 @@ export function extractRangesFromTokens (editor: monaco.editor.ICodeEditor, star
   return []
 }
 
-export function createDecorationsForRanges (
-  editor: monaco.editor.ICodeEditor,
-  ranges: monaco.IRange[],
-  options: monaco.editor.IModelDecorationOptions
-): monaco.editor.IEditorDecorationsCollection {
-  const decorations = ranges.map((range) => ({ options, range }))
-  return editor.createDecorationsCollection(decorations)
-}
-
 export interface LockCodeOptions {
   /**
    * Error message displayed in a tooltip when an edit failed

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -268,51 +268,6 @@ function lockCodeWithDecoration (
   return disposableStore
 }
 
-function lockCodeWithRanges (
-  editor: monaco.editor.ICodeEditor,
-  {
-    errorMessage,
-    allowChangeFromSources = [],
-    transactionMode = true,
-    allowUndoRedo = true
-  }: Omit<LockCodeOptions, 'decorationFilter'>,
-  ranges: monaco.Range[],
-  decorationOptions: monaco.editor.IModelDecorationOptions,
-  /**
-   * If true, the code within the ranges will be locked.
-   * All the code outside of the ranges will be lock otherwise.
-   */
-  fromRanges: boolean
-): monaco.IDisposable {
-  const decorations = createDecorationsForRanges(editor, ranges, decorationOptions)
-  return lockCodeWithDecoration(editor, {
-    decorationFilter: (deco) =>
-      decorations.has(deco),
-    errorMessage,
-    allowChangeFromSources,
-    transactionMode,
-    allowUndoRedo
-  }, fromRanges)
-}
-
-export function lockCodeSectionsFromRanges (
-  editor: monaco.editor.ICodeEditor,
-  lockOptions: Omit<LockCodeOptions, 'decorationFilter'>,
-  ranges: monaco.Range[],
-  decorationOptions: monaco.editor.IModelDecorationOptions
-): monaco.IDisposable {
-  return lockCodeWithRanges(editor, lockOptions, ranges, decorationOptions, true)
-}
-
-export function lockCodeSectionsWithoutRanges (
-  editor: monaco.editor.ICodeEditor,
-  lockOptions: Omit<LockCodeOptions, 'decorationFilter'>,
-  ranges: monaco.Range[],
-  decorationOptions: monaco.editor.IModelDecorationOptions
-): monaco.IDisposable {
-  return lockCodeWithRanges(editor, lockOptions, ranges, decorationOptions, false)
-}
-
 export function lockCodeFromDecoration (
   editor: monaco.editor.ICodeEditor,
   lockOptions: LockCodeOptions

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -276,6 +276,36 @@ function lockCodeWithDecoration (
   return lockCodeWithRanges(editor, { errorMessage, allowChangeFromSources, transactionMode, allowUndoRedo }, ranges, fromRanges)
 }
 
+export function lockCodeSectionsFromRanges (
+  editor: monaco.editor.ICodeEditor,
+  lockOptions: Omit<LockCodeOptions, 'decorationFilter'>,
+  ranges: monaco.Range[]
+): monaco.IDisposable {
+  return lockCodeWithRanges(editor, lockOptions, ranges, true)
+}
+
+export function lockCodeSectionsWithoutRanges (
+  editor: monaco.editor.ICodeEditor,
+  lockOptions: Omit<LockCodeOptions, 'decorationFilter'>,
+  ranges: monaco.Range[]
+): monaco.IDisposable {
+  return lockCodeWithRanges(editor, lockOptions, ranges, false)
+}
+
+export function lockCodeFromDecoration (
+  editor: monaco.editor.ICodeEditor,
+  lockOptions: LockCodeOptions
+): monaco.IDisposable {
+  return lockCodeWithDecoration(editor, lockOptions, true)
+}
+
+export function lockCodeWithoutDecoration (
+  editor: monaco.editor.ICodeEditor,
+  lockOptions: LockCodeOptions
+): monaco.IDisposable {
+  return lockCodeWithDecoration(editor, lockOptions, false)
+}
+
 let hideCodeWithoutDecorationCounter = 0
 export function hideCodeWithoutDecoration (editor: monaco.editor.ICodeEditor, decorationFilter: (decoration: monaco.editor.IModelDecoration) => boolean): monaco.IDisposable {
   const hideId = `hideCodeWithoutDecoration:${hideCodeWithoutDecorationCounter++}`

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -128,6 +128,7 @@ function lockCodeUsingDecoration (
 
   const originalTrigger = editor.trigger
   editor.trigger = function (source, handlerId, payload) {
+    // Try to transform whole file pasting into a paste in the editable area only
     const ranges = getRangesFromDecorations(editor, decorationFilter)
     const lastEditableRange =
       ranges.length > 0 ? ranges[ranges.length - 1] : undefined

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -334,10 +334,9 @@ export function hideCodeWithoutDecoration (editor: monaco.editor.ICodeEditor, de
 }
 
 /**
- * Collapse everything between startToken and endToken
+ * Collapse everything from ranges
  */
-export async function collapseCodeSections (editor: monaco.editor.ICodeEditor, startToken: string, endToken: string, isRegex: boolean = false): Promise<void> {
-  const ranges: monaco.IRange[] = extractRangesFromTokens(editor, startToken, endToken, isRegex)
+export async function collapseCodeSectionsFromRanges (editor: monaco.editor.ICodeEditor, ranges: monaco.IRange[]): Promise<void> {
   if (ranges.length > 0) {
     const selections = editor.getSelections()
     editor.setSelections(ranges.map(r => ({
@@ -351,6 +350,14 @@ export async function collapseCodeSections (editor: monaco.editor.ICodeEditor, s
       editor.setSelections(selections)
     }
   }
+}
+
+/**
+ * Collapse everything between startToken and endToken
+ */
+export async function collapseCodeSections (editor: monaco.editor.ICodeEditor, startToken: string, endToken: string, isRegex: boolean = false): Promise<void> {
+  const ranges: monaco.IRange[] = extractRangesFromTokens(editor, startToken, endToken, isRegex)
+  await collapseCodeSectionsFromRanges(editor, ranges)
 }
 
 interface IDecorationProvider {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -97,7 +97,7 @@ export interface LockCodeOptions {
   allowUndoRedo?: boolean
 }
 
-function lockCodeWithDecoration (
+function lockCodeUsingDecoration (
   editor: monaco.editor.ICodeEditor,
   {
     errorMessage,
@@ -107,10 +107,10 @@ function lockCodeWithDecoration (
     allowUndoRedo = true
   }: LockCodeOptions,
   /**
-   * If true, the code within the ranges will be locked.
-   * All the code outside of the ranges will be lock otherwise.
+   * If true, the code within the decoration will be locked.
+   * All the code outside of the decoration will be locked otherwise.
    */
-  fromRanges: boolean
+  withDecoration: boolean
 ): monaco.IDisposable {
   const disposableStore = new DisposableStore()
   function displayLockedCodeError (position: monaco.Position) {
@@ -130,7 +130,7 @@ function lockCodeWithDecoration (
     if (ranges.length === 0) {
       return true
     }
-    return fromRanges
+    return withDecoration
       ? ranges.every((uneditableRange) => !uneditableRange.containsRange(range))
       : ranges.some((editableRange) => editableRange.containsRange(range))
   }
@@ -268,18 +268,18 @@ function lockCodeWithDecoration (
   return disposableStore
 }
 
-export function lockCodeFromDecoration (
+export function lockCodeWithDecoration (
   editor: monaco.editor.ICodeEditor,
   lockOptions: LockCodeOptions
 ): monaco.IDisposable {
-  return lockCodeWithDecoration(editor, lockOptions, true)
+  return lockCodeUsingDecoration(editor, lockOptions, true)
 }
 
 export function lockCodeWithoutDecoration (
   editor: monaco.editor.ICodeEditor,
   lockOptions: LockCodeOptions
 ): monaco.IDisposable {
-  return lockCodeWithDecoration(editor, lockOptions, false)
+  return lockCodeUsingDecoration(editor, lockOptions, false)
 }
 
 let hideCodeWithoutDecorationCounter = 0


### PR DESCRIPTION
Adds the functions:
- `collapseCodeSectionsFromRanges` to collapse code within ranges
- `lockCodeSectionsFromRanges` to lock code within ranges
- `lockCodeSectionsWithoutRanges` to lock code outside of ranges
- `lockCodeFromDecoration` to lock code with decorations
- `extractRangesFromTokens` to extract code between 2 tokens