### PR TITLE
Do not enable global keybindings

### DIFF
--- a/src/services.ts
+++ b/src/services.ts
@@ -68,11 +68,7 @@ let services: monaco.editor.IEditorOverrideServices = {
   ...getModelServiceOverride(),
   ...getDialogsServiceOverride(),
   ...getConfigurationServiceOverride(),
-  ...getKeybindingsServiceOverride({
-    shouldUseGlobalKeybindings() {
-      return useGlobalPicker()
-    }
-  }),
+  ...getKeybindingsServiceOverride(),
   ...getTextmateServiceOverride(),
   ...getThemeServiceOverride(),
   ...getLanguagesServiceOverride(),


### PR DESCRIPTION
because it prevent ctrl+f from working outside of the editor