### PR TITLE
Add Vue extension

### DIFF
--- a/vscode-extensions.json
+++ b/vscode-extensions.json
@@ -128,5 +128,10 @@
     "publisher": "golang",
     "name": "Go",
     "version": "0.47.2"
+  },
+  {
+    "publisher": "Vue",
+    "name": "volar",
+    "version": "3.0.1"
   }
 ]


### PR DESCRIPTION
Name: Vue (Official)
Id: Vue.volar
Description: Language Support for Vue
Version: 3.0.1
Publisher: Vue
VS Marketplace Link: [https://marketplace.visualstudio.com/items\?itemName\=Vue.volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar)