### PR TITLE
fix: filter icon fields from manifests to prevent csp violations

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -154,6 +154,7 @@ ${files.map((_, index) => `    whenReady${index}()`).join(',\n')}
           viewsContainers,
           typescriptServerPlugins,
           configurationDefaults,
+          icons,
           ...remainingContribute
         } = (manifest.contributes ?? {}) as IExtensionManifest['contributes'] & {
           typescriptServerPlugins: unknown // typescript extension specific field


### PR DESCRIPTION
The Terraform extension was causing Content Security Policy violations in the browser console with errors like:

```
Refused to load the font 'extension-file://hashicorp.terraform/extension/assets/icons/running.woff' because it violates the following Content Security Policy directive....
```

The HashiCorp Terraform extension puts custom icons in its package.json manifest:
- contributes.icons

The rollup-vsix-plugin has a bug that fails to detect and bundle these icon paths properly.

Need to filter out icon-related fields from extension manifests:
- icons (under contributes)
